### PR TITLE
Fix tabs not working when using MB Builder

### DIFF
--- a/src/Parsers/MetaBox.php
+++ b/src/Parsers/MetaBox.php
@@ -33,11 +33,12 @@ class MetaBox extends Base {
 			$this->settings['validation'] = $this->validation;
 		}
 
+		$this->settings = array_merge( [ 'fields' => $this->fields ], $settings );
 		$this->settings = apply_filters( 'mbb_meta_box_settings', $this->settings );
 
 		// Remove array keys again. Some methods like parse tabs change fields.
 		$this->fields   = array_values( $this->fields );
-		$this->settings = array_merge( [ 'fields' => $this->fields ], $settings );
+		$this->settings['fields'] = $this->fields;
 	}
 
 	private function parse_settings() {

--- a/src/Parsers/MetaBox.php
+++ b/src/Parsers/MetaBox.php
@@ -24,7 +24,11 @@ class MetaBox extends Base {
 
 		$this->remove_empty_values();
 
-		$settings = $this->settings_parser->get_settings();
+		// Remove array keys again. Some methods like parse tabs change fields.
+		$this->fields = array_values( $this->fields );
+
+		$settings       = $this->settings_parser->get_settings();
+		$this->settings = array_merge( $settings, [ 'fields' => $this->fields ] );
 
 		if ( $this->validation['rules'] ) {
 			if ( empty( $this->validation['messages'] ) ) {
@@ -33,11 +37,10 @@ class MetaBox extends Base {
 			$this->settings['validation'] = $this->validation;
 		}
 
-		$this->settings = array_merge( [ 'fields' => $this->fields ], $settings );
 		$this->settings = apply_filters( 'mbb_meta_box_settings', $this->settings );
 
 		// Remove array keys again. Some methods like parse tabs change fields.
-		$this->fields   = array_values( $this->fields );
+		$this->fields             = array_values( $this->fields );
 		$this->settings['fields'] = $this->fields;
 	}
 


### PR DESCRIPTION
https://app.asana.com/1/11768486970802/project/1200179452020411/task/1209883539277223
Bug này do khi parse MetaBox ở [PR này ](https://github.com/wpmetabox/mbb-parser/pull/11/files#diff-7a0f373db1bd80da207db64ebe00989f4a25047e277be8266f6cc9f05e595e71) thì mình không lấy các settings của hook