### PR TITLE
Fix: Filter allowed blocks through AllowedBlockLists::filter_valid_blocks()

### DIFF
--- a/src/Unparsers/Field.php
+++ b/src/Unparsers/Field.php
@@ -250,7 +250,7 @@ class Field extends Base {
 		}
 
 		$lists  = \MBB\Helpers\AllowedBlockLists::get_lists();
-		$blocks = (array) $this->allowed_blocks;
+		$blocks = \MBB\Helpers\AllowedBlockLists::filter_valid_blocks( (array) $this->allowed_blocks );
 
 		// Check if a list with the same blocks already exists.
 		foreach ( $lists as $id => $list ) {


### PR DESCRIPTION
Bug được report trong ticket: https://helpdesk.elightup.com/conversation/13686?folder_id=35

**Lỗi xảy ra**
- PHP Fatal error: `Allowed memory size exhausted (256MB)`.

**Nguyên nhân**
- Meta Box Builder (trong Meta Box AIO mà khách đang sử dụng) lưu danh sách allowed blocks vào option `mbb_allowed_block_lists`.
- Option này đã phình lên rất lớn (lên tới vài chục MB), khiến quá trình xử lý bị vượt quá giới hạn bộ nhớ PHP.

**Đoạn code gây ra vấn đề**
- `vendor/wpmetabox/mbb-parser/src/Unparsers/Field.php`
- Hàm: `unparse_field_block_editor()`

**Giải thích**
Khách trước đây đã cài một plugin tên **gothe** (hiện đã deactivate), plugin này đăng ký hai block:
- `consenta/conditional-content`
- `consenta/consent-status`

Hai block này vẫn còn được lưu trong database.

Trong mỗi lần chạy:
- `$list` chỉ chứa danh sách các block hiện đang được đăng ký.
- `$blocks` lại vẫn chứa cả `consenta/conditional-content` và `consenta/consent-status`.

Do `$list` và `$blocks` luôn khác nhau, Meta Box Builder luôn tạo một danh sách mới và ghi lại vào option `mbb_allowed_block_lists`, khiến option này liên tục phình to theo thời gian.

**Giải pháp**
Lọc bỏ các block không còn được đăng ký trước khi so sánh:

```php
$blocks = \MBB\Helpers\AllowedBlockLists::filter_valid_blocks( (array) $this->allowed_blocks );
```

Việc này sẽ loại bỏ các block không hợp lệ, giúp `$blocks` chỉ chứa các block đang được đăng ký và ngăn option `mbb_allowed_block_lists` tiếp tục tăng kích thước không cần thiết.